### PR TITLE
:wrench: update gradle to secured protocol

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ project.ext.isSnapshot = version.endsWith("-SNAPSHOT")
 // Include jars for the artifactory plugin
 buildscript {
     repositories {
-        maven { url 'http://jcenter.bintray.com' }
+        maven { url 'https://jcenter.bintray.com' }
     }
     dependencies {
         classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '2.0.9')


### PR DESCRIPTION
This PR updated the `'http'` protocol to `'https'` as Gradle doesn't support `'http'` protocols anymore. Please see the [blog](https://blog.gradle.org/decommissioning-http) for your reference. 