### PR TITLE
MYRPF-6809, MYRPF-6812 - [PV] Implement User Data Consent for Firefox and Safari

### DIFF
--- a/widgets/bootstrap/responsivePage/0.1/productionFooter.jsp
+++ b/widgets/bootstrap/responsivePage/0.1/productionFooter.jsp
@@ -15,8 +15,7 @@
             data-dismiss="modal" 
             type="button" 
             style="color:#fff;border:0;margin:0;" 
-            class="btn orange-btn" 
-            onclick="setCookie('cookies_accepted',true,1000)">
+            class="btn orange-btn">
               Accept
           </button>
 				</div>
@@ -110,6 +109,27 @@
 				if(!getCookie('cookies_accepted') && serverUrl === locationOrigin){
 					jQuery('#accept_cookies_modal').modal();
 				};
+				
+				var localUrl = '<%=Encode.forJavaScriptBlock(Config.getValue("freemium.server.is.localhost"))%>' === 'true'
+				    ? '/ttsvr' : '';
+				
+				var cookieUrl = serverUrl + localUrl + "/private/cookieConsent";
+				jQuery('#acceptCookieButton').click(function() {
+					setCookie('cookies_accepted', true, 160);
+					
+                   jQuery.ajax({
+                        type: 'GET',
+                        url: cookieUrl,
+                        success: function(data) {
+                            if (!data) return;
+                            
+                            console.log("Successful setting cookie consent with identifier ID: '" + identifierId + "'");
+                        },
+                        error: function(error) {
+                            console.error('Failed request from cookie consent ');
+                        }
+                    });
+				});
 			});
 		</script>
 </html><!-- This should be the end -->


### PR DESCRIPTION
**Ticket:** [MYRPF-6809](http://jira.rpdata.local/browse/MYRPF-6809), [MYRPF-6812](http://jira.rpdata.local/browse/MYRPF-6812)

## PR Dependencies:
* [rpdata-myrp PR#313](https://github.com/twistresources/rpdata-myrp/pull/313)

## Merge request description
### What is new?
Implemented ways to set a cookie from `Set-Cookie` response header for Firefox and Safari.

The cookies are requested from the new servlet URL endpoint. 
`/private/cookieConsent`

<img width="1552" alt="Screen Shot 2020-07-10 at 13 35 24" src="https://user-images.githubusercontent.com/45745191/87121111-a8326c00-c2b4-11ea-95c0-96d5a3d4bb99.png">

<img width="1552" alt="Screen Shot 2020-07-10 at 13 35 31" src="https://user-images.githubusercontent.com/45745191/87121120-ab2d5c80-c2b4-11ea-9bb3-b0191d3b19f8.png">

Rules for the cookie:
* Cookie name can be anything as long as it is the same across your sites and instances. Our recommendation is to name it `kppid`.
* Cookie value should be 11-character alphanumeric (a-z, 0-9, _)
* Cookies expiry can be set per client's lookback needs and we recommend setting it to `6` months
* Cookie domain should be the site's domain e.g., domain = ".customer.com" on www.customer.com

### What has changed?
Servlet mappings and the accept cookie behavior, it was now reduced to less than 6 months expiry.

**Checklist:**
✅ I ran this code locally
⏩ I tested it and updated the TestRail - Will update when the TC becomes available.
✅ I updated the release artifacts

**Legend:**
❌ Not yet performed
✅ performed 
⏩ skipped as not applicable

## Reviewer should know about
### Is there anything else that should be known?
References for this story:
[Safari 1st Party Cookies](https://konsole.zendesk.com/hc/en-us/articles/360037845413-Safari-1st-Party-Cookies)
[Firefox 1st Party Cookies](https://konsole.zendesk.com/hc/en-us/articles/360044750613-Firefox-1st-Party-Cookies)
[Today’s Firefox Blocks Third-Party Tracking Cookies and Cryptomining by Default](https://blog.mozilla.org/blog/2019/09/03/todays-firefox-blocks-third-party-tracking-cookies-and-cryptomining-by-default/)
[JavaScript Consent Tag Spec](https://konsole.zendesk.com/hc/en-us/articles/360000754674-JavaScript-Consent-Tag-Spec)
[Consumer Rights Management - Concepts & Glossary of Terms](https://konsole.zendesk.com/hc/en-us/articles/360000486853)

✅ The reviewer can now merge the PR and delete the branch.
